### PR TITLE
fix(ws): RFC-compliant subprotocol echo, scrub token logs; add DO state handle

### DIFF
--- a/src/durable-objects/progress-socket.js
+++ b/src/durable-objects/progress-socket.js
@@ -63,6 +63,7 @@ const THROTTLE_CONFIG = {
 export class ProgressWebSocketDO extends DurableObject {
   constructor(state, env) {
     super(state, env);
+    this.state = state; // Ensure state is available outside of storage helpers
     this.storage = state.storage; // Durable Object storage for cancellation state
     this.webSocket = null;
     this.jobId = null;
@@ -96,7 +97,7 @@ export class ProgressWebSocketDO extends DurableObject {
     const upgradeHeader = request.headers.get("Upgrade");
 
     console.log("[ProgressDO] Incoming request", {
-      url: url.toString(),
+      path: url.pathname,
       upgradeHeader,
       method: request.method,
       timestamp: upgradeStartTime,
@@ -494,8 +495,8 @@ export class ProgressWebSocketDO extends DurableObject {
     // SECURITY FIX (Issue #163): Include Sec-WebSocket-Protocol in upgrade response
     const headers = getCorsHeaders(request);
     if (tokenSource === "subprotocol") {
-      // Confirm the bookstrack-auth subprotocol (required by WebSocket RFC 6455)
-      headers["Sec-WebSocket-Protocol"] = "bookstrack-auth";
+      // Echo the exact subprotocol value offered by the client (RFC 6455 requirement)
+      headers["Sec-WebSocket-Protocol"] = wsProtocol;
     }
 
     return new Response(null, {


### PR DESCRIPTION
Summary
- WebSocket subprotocol echo now RFC 6455 compliant by echoing the exact Sec-WebSocket-Protocol value offered by the client. Prevents sporadic handshake failures.
- Removed URL logging on WebSocket upgrade to avoid leaking tokens when legacy query-param auth is still in use.
- Ensure Durable Object has a stable this.state reference for alarm/log usage.

Context
Recent production observations showed intermittent WebSocket upgrade failures and token exposure risk in logs when legacy query-param token fallback is used. Also noticed potential undefined access for this.state in alarm logging code paths.

Changes
1. progress-socket.js
   - Echo the exact subprotocol (e.g., "bookstrack-auth.<token>") instead of a fixed value ("bookstrack-auth").
   - Stop logging full URL in upgrade path; log pathname only (no query string) to prevent token leakage.
   - Save this.state = state in constructor; used later for robust logging in alarm paths.

Risk/Impact
- Backward compatible. New subprotocol echo matches the client-offered value, which all compliant clients already send.
- Logging change only reduces sensitive data exposure and has no functional impact.
- this.state addition is internal plumbing only.

Testing
- Local wrangler dev: verified that subprotocol from client is echoed back and connections establish successfully.
- Confirmed no URL with token appears in logs during WS upgrade.

Follow-ups (separate PRs recommended)
- Router parity: Hono default enablement still lacks some manual routes (e.g., /api/token/refresh, /api/job-state/:jobId, /api/scan-bookshelf/cancel). Either add parity routes or keep ENABLE_HONO_ROUTER=false by default.
- CORS policy consolidation: unify allowed origins and fix "* + credentials" mismatch.

Checklist
- [x] No breaking API changes
- [x] Security improvement (reduced token exposure)
- [x] Adheres to existing coding style

Co-authored-by: openhands <openhands@all-hands.dev>

@jukasdrj can click here to [continue refining the PR](https://app.all-hands.dev/conversations/97f1342d593c4f288bd61e297a5a0adc)